### PR TITLE
refactor: update default assistant config

### DIFF
--- a/src/autogluon/assistant/configs/default.yaml
+++ b/src/autogluon/assistant/configs/default.yaml
@@ -12,7 +12,7 @@ max_num_tutorials: 5
 max_user_input_length: 2048
 max_error_message_length: 2048
 max_tutorial_length: 32768
-create_venv: false
+create_venv: False
 condense_tutorials: True
 use_tutorial_summary: True
 continuous_improvement: False
@@ -25,11 +25,7 @@ llm: &default_llm
   # Note: bedrock is only supported in limited AWS regions
   #       and requires AWS credentials
   provider: bedrock
-  model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-  #provider: openai
-  #model: gpt-4o-2024-08-06
-  #provider: anthropic
-  # model: claude-3-7-sonnet-20250219
+  model: "apac.anthropic.claude-sonnet-4-20250514-v1:0"
   max_tokens: 65535
   proxy_url: null
   temperature: 0.1
@@ -40,40 +36,51 @@ llm: &default_llm
   add_coding_format_instruction: false
 
 coder:
-  <<: *default_llm  # Merge llm_config
+  <<: *default_llm
   multi_turn: True
 
 executer:
-  <<: *default_llm  # Merge llm_config
+  <<: *default_llm
   max_stdout_length: 8192
   max_stderr_length: 2048
 
+
 reader:
-  <<: *default_llm  # Merge llm_config
+  provider: openai
+  model: "gpt-4.1-2025-04-14"
+  max_tokens: 32768
+  proxy_url: null
+  temperature: 0.1
+  top_p: 0.9
+  verbose: True
+  multi_turn: False
+  template: null
+  add_coding_format_instruction: False
   details: False
 
 error_analyzer:
-  <<: *default_llm  # Merge llm_config
+  <<: *default_llm
 
 retriever:
-  <<: *default_llm  # Merge llm_config
+  <<: *default_llm
 
 reranker:
-  <<: *default_llm  # Merge llm_config
-  temperature: 0.
-  top_p: 1.
+  <<: *default_llm
+  temperature: 0.0
+  top_p: 1.0
 
 description_file_retriever:
-  <<: *default_llm  # Merge llm_config
-  temperature: 0.
-  top_p: 1.
+  <<: *default_llm
+  temperature: 0.0
+  top_p: 1.0
 
 task_descriptor:
-  <<: *default_llm  # Merge llm_config
+  <<: *default_llm
   max_description_files_length_to_show: 1024
   max_description_files_length_for_summarization: 16384
 
 tool_selector:
-  <<: *default_llm  # Merge llm_config
-  temperature: 0.
-  top_p: 1.
+  <<: *default_llm
+  temperature: 0.0
+  top_p: 1.0
+


### PR DESCRIPTION
## Summary
- update `default.yaml` with new tutorial and LLM configuration

## Testing
- `pytest tests/unittests` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant', ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6895071fbedc8326a71c6fed2a3d2292