### PR TITLE
Fix typo in reranker LLM config variable

### DIFF
--- a/src/autogluon/assistant/agents/reranker_agent.py
+++ b/src/autogluon/assistant/agents/reranker_agent.py
@@ -28,7 +28,7 @@ class RerankerAgent(BaseAgent):
 
         if self.reranker_llm_config.multi_turn:
             self.reranker_llm = init_llm(
-                llm_config=self.rerankerl_llm_config,
+                llm_config=self.reranker_llm_config,
                 agent_name="reranker",
                 multi_turn=self.reranker_llm_config.multi_turn,
             )


### PR DESCRIPTION
## Summary
- fix variable name typo in `RerankerAgent`

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic'; ModuleNotFoundError: No such file or directory 'mlzero-mcp-client')*

------
https://chatgpt.com/codex/tasks/task_e_68963337041c8326a74d038456767da8