### PR TITLE
Ensure best_run folder exists before moving env

### DIFF
--- a/src/autogluon/assistant/managers/manager.py
+++ b/src/autogluon/assistant/managers/manager.py
@@ -575,6 +575,7 @@ class Manager:
                     shutil.copytree(source_item, dest_item, dirs_exist_ok=True)
 
             if self.config.cleanup_unused_env:
+                os.makedirs(best_run_folder, exist_ok=True)
                 # Move conda_env folder from source to best_run folder
                 shutil.move(
                     os.path.join(source_folder, ENV_FOLDER_NAME), os.path.join(best_run_folder, ENV_FOLDER_NAME)


### PR DESCRIPTION
## Summary
- create best_run folder before moving conda environment when cleanup is enabled

## Testing
- `python -m pytest tests/unittests -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant'; No module named 'pytest_asyncio'; No module named 'streamlit')*
- `python - <<'PY'
import os, shutil, tempfile
from types import SimpleNamespace

# replicate function logic
ENV_FOLDER_NAME = 'conda_env'
class DummyManager:
    def __init__(self, output_folder, cleanup_unused_env=True):
        self.output_folder=output_folder
        self.config=SimpleNamespace(cleanup_unused_env=cleanup_unused_env)
        self.best_step=0
        self.best_validation_score=0.0
        self.last_successful_step=0
        self.best_step_saved=-1
    def get_validation_score_summary(self):
        return ''
    def save_and_log_states(self, **kwargs):
        pass
    def create_best_run_copy(self):
        target_step=self.best_step if self.best_step>=0 else self.last_successful_step
        source_folder=os.path.join(self.output_folder,f'generation_iter_{target_step}')
        best_run_folder=os.path.join(self.output_folder,'best_run')
        source_output_folder=os.path.join(source_folder,'output')
        if os.path.exists(best_run_folder):
            shutil.rmtree(best_run_folder)
        for item in os.listdir(source_output_folder):
            source_item=os.path.join(source_output_folder,item)
            dest_item=os.path.join(self.output_folder,item)
            if os.path.isfile(source_item):
                shutil.copy2(source_item,dest_item)
            elif os.path.isdir(source_item):
                shutil.copytree(source_item,dest_item,dirs_exist_ok=True)
        if self.config.cleanup_unused_env:
            os.makedirs(best_run_folder,exist_ok=True)
            shutil.move(os.path.join(source_folder,ENV_FOLDER_NAME),os.path.join(best_run_folder,ENV_FOLDER_NAME))
        shutil.copytree(source_folder,best_run_folder,dirs_exist_ok=True)

# Setup temp dirs
tmp=tempfile.mkdtemp()
source=os.path.join(tmp,'generation_iter_0')
os.makedirs(source)
os.makedirs(os.path.join(source,'output'))
with open(os.path.join(source,'output','file.txt'),'w') as f: f.write('x')
os.makedirs(os.path.join(source,ENV_FOLDER_NAME))

m=DummyManager(tmp,cleanup_unused_env=True)
try:
    m.create_best_run_copy()
    print('best_run contents:',os.listdir(os.path.join(tmp,'best_run')))
except FileNotFoundError as e:
    print('FileNotFoundError:',e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68963bdd880083269af43d3a78efb81e