### PR TITLE
docs: assume gpu environment for autogluon tabular

### DIFF
--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates how to create and use custom evaluation metrics in AutoGluon, focusing on what makes them better for model optimization. It covers the implementation of custom metrics for classification, regression, and probability-based tasks, with examples of accuracy, ROC AUC, and MSE. The metrics are defined using make_scorer and can be used for model evaluation and comparison.
@@ -8,7 +10,7 @@ Summary: This tutorial demonstrates how to create and use custom evaluation metr
 
 ## Setup
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 import numpy as np
 from autogluon.core.metrics import make_scorer
 import sklearn.metrics

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates how to prevent AutoGluon from dropping specific features during preprocessing. It covers three key techniques: (1) creating custom models with the `drop_unique=False` parameter to preserve single-value features, (2) implementing a `CustomFeatureGeneratorWithUserOverride` that uses `IdentityFeatureGenerator` to bypass preprocessing for tagged features, and (3) tagging features with special types like 'user_override' to control their processing. These methods are valuable for maintaining important features in machine learning pipelines, ensuring model interpretability, and handling domain-specific features that shouldn't undergo standard transformations.
@@ -9,7 +11,7 @@ Summary: This tutorial demonstrates how to prevent AutoGluon from dropping speci
 ## Setup and Data Loading
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 from autogluon.tabular import TabularDataset
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates how to implement custom models in AutoGluon by extending the AbstractModel class, specifically creating a custom RandomForest implementation. It covers preprocessing with label encoding, dynamic model selection based on problem type, and proper integration with AutoGluon's ecosystem. Key functionalities include custom model training, feature preprocessing, model saving/loading, bagged ensembles for improved performance, and hyperparameter tuning using search spaces. The tutorial helps with tasks like implementing custom ML algorithms within AutoGluon, integrating models with TabularPredictor, and optimizing model performance through bagging and hyperparameter optimization.
@@ -8,7 +10,7 @@ Summary: This tutorial demonstrates how to implement custom models in AutoGluon 
 
 ## Installation and Setup
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 ```
 
 ## Creating a Custom Random Forest Model

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-deployment.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-deployment.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: AutoGluon Tabular predictor deployment tutorial provides a guide to AutoGluon TabularPredictor deployment
@@ -26,7 +28,7 @@ AI: Summary: AutoGluon TabularPredictor deployment guide provides practical tech
 
 ```python
 # Install AutoGluon
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 # Load data and train model
 from autogluon.tabular import TabularDataset, TabularPredictor
@@ -89,7 +91,7 @@ print(f'Optimized predictor achieved a {round((1 - (size_opt/size_original)) * 1
 ## Compile Models for Maximum Speed
 
 ```python
-# Install required packages: pip install autogluon.tabular[all,skl2onnx]
+# Install required packages: pip install autogluon.tabular[all,skl2onnx,tabarena]
 predictor_clone_opt.compile()
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial explains GPU acceleration in AutoGluon, covering basic GPU allocation with `num_gpus` parameter, model-specific GPU assignment using hyperparameters dictionary, and multi-modal configuration retrieval. It details special installation requirements for GPU-enabled LightGBM and demonstrates advanced resource allocation techniques to control CPU/GPU usage at predictor, ensemble, and individual model levels. The tutorial helps with optimizing machine learning workflows by efficiently distributing computational resources across different models and training processes, particularly useful for implementing parallel hyperparameter optimization with controlled resource allocation for tabular, multimodal, and gradient-boosted models.

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-kaggle.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-kaggle.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```
 
 Summary: This tutorial demonstrates how to use AutoGluon for fraud detection in the IEEE Fraud detection competition. AutoGluon's TabularPredictor can be used to train a model for binary classification with minimal code. It shows how to use TabularPredictor for binary classification with TabularPredictor for binary classification with TabularPredictor for binary classification.

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-multilabel.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-multilabel.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates AutoGluon's MultilabelPredictor implementation for predicting multiple target columns simultaneously. It covers creating a custom class that manages multiple TabularPredictors, with methods for training, prediction, evaluation, and model persistence. Key features include handling different problem types (regression, classification) for each target, optional correlation consideration between labels during prediction, and customizable evaluation metrics. The code helps with multi-target machine learning tasks, offering flexibility in how predictions are generated and evaluated. The implementation provides a clean API for training multiple models with a single interface while maintaining individual model access.
@@ -8,7 +10,7 @@ Summary: This tutorial demonstrates AutoGluon's MultilabelPredictor implementati
 
 ## Installation
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 ```
 
 ## Implementation

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-essentials.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-essentials.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial covers AutoGluon's TabularPredictor for automated machine learning on tabular data. It demonstrates implementation of quick model training with minimal code, automated handling of data preprocessing, and model deployment. Key functionalities include: loading tabular data, training multiple models simultaneously, making predictions, evaluating performance, and saving/loading models. The tutorial explains different performance presets (from "medium" to "extreme"), feature importance analysis, and optimization strategies for classification and regression tasks. AutoGluon automatically handles missing values, feature engineering, and model selection, making it valuable for rapid prototyping and production-quality predictive modeling with just a few lines of code.
@@ -9,7 +11,7 @@ Summary: This tutorial covers AutoGluon's TabularPredictor for automated machine
 ## Setup and Installation
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 from autogluon.tabular import TabularDataset, TabularPredictor
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```
 
 Summary: This tutorial explains AutoGluon's automatic feature engineering capabilities for tabular data. It covers type-specific processing: numerical columns remain unchanged, categorical columns are integer-encoded, datetime columns are converted to numerical values with extracted temporal features (year, month, day, weekday), and text columns use either n-gram encoding or Transformer networks with MultiModal. The tutorial demonstrates how to implement custom feature generation pipelines using PipelineFeatureGenerator, CategoryFeatureGenerator, and IdentityFeatureGenerator classes, with examples of limiting categorical values and handling specific data types. It also addresses missing value handling and provides tips for customizing the feature engineering process.

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: Installation
 
 Summary: This tutorial demonstrates implementing foundation models for tabular data using AutoGluon. It covers three key models: Mitra (for small datasets with zero-shot and fine-tuning capabilities), TabICL (leveraging in-context learning for limited data), and TabPFNv2 (utilizing prior knowledge for small datasets). The code shows how to prepare data, train individual models for classification and regression tasks, and create ensembles combining multiple foundation models. Developers can learn to implement these specialized tabular models with different configurations, evaluate their performance, and handle both classification and regression problems with small to medium-sized datasets.
@@ -11,9 +13,9 @@ Summary: This tutorial demonstrates implementing foundation models for tabular d
 ```python
 # Install required packages
 !pip install uv
-!uv pip install autogluon.tabular[mitra]   # For Mitra
-!uv pip install autogluon.tabular[tabicl]   # For TabICL
-!uv pip install autogluon.tabular[tabpfn]   # For TabPFNv2
+!uv pip install autogluon.tabular[mitra,tabarena]   # For Mitra
+!uv pip install autogluon.tabular[tabicl,tabarena]   # For TabICL
+!uv pip install autogluon.tabular[tabpfn,tabarena]   # For TabPFNv2
 
 import pandas as pd
 from autogluon.tabular import TabularDataset, TabularPredictor

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates AutoGluon TabularPredictor for machine learning tasks, covering hyperparameter tuning with search spaces for neural networks and gradient boosting models, model ensembling through stacking/bagging, and decision threshold calibration for binary classification. It explains inference optimization techniques including model persistence, inference speed constraints, ensemble reduction, and model distillation. The tutorial provides practical code examples for accelerating predictions (up to 160x speedup), managing memory usage, and evaluating model performance. Key functionalities include feature importance analysis, loading/saving predictors, making batch and single-instance predictions, and optimizing deployment with techniques like refit_full, persist, and infer_limit parameters.
@@ -9,7 +11,7 @@ Summary: This tutorial demonstrates AutoGluon TabularPredictor for machine learn
 ## Setup and Data Loading
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 from autogluon.tabular import TabularDataset, TabularPredictor
 import numpy as np

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: This tutorial demonstrates using AutoGluon Multimodal for multimodal classification on the PetFinder dataset. It covers: (1) implementing multimodal machine learning with images and tabular data, including proper image path handling and feature metadata configuration; (2) solving pet adoption prediction tasks by integrating different data types; and (3) key functionalities including data preparation for multimodal inputs, configuring feature metadata to identify image columns, creating appropriate hyperparameter configurations, and training a TabularPredictor that automatically handles mixed data types. The tutorial showcases how to process image paths, configure models for multimodal inputs, and evaluate performance on test data.
@@ -9,7 +11,7 @@ Summary: This tutorial demonstrates using AutoGluon Multimodal for multimodal cl
 ## Setup and Data Preparation
 
 ```python
-!pip install autogluon
+!pip install autogluon[tabarena]
 
 # Download and extract dataset
 download_dir = './ag_petfinder_tutorial'

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-quick-start.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-quick-start.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 # Condensed: ```python
 
 Summary: "Summary: "Tabular: "Tabular: "Tabular Hypersc 'Hypersc 'Hypertuning 1.Hat 'Hypertuning 'Hypertuning 'Hyperturf: "Hypertuning 'Hyperparred 'Hyperparcel: "Hypertuner: "Hyperturf: "Hypertuner: "Hypertuner: "Hyperturf: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hyperparameter Tuning"
@@ -11,7 +13,7 @@ Summary: This tutorial demonstrates AutoGluon for automated machine learning wit
 ## Setup
 ```python
 !python -m pip install --upgrade pip
-!python -m pip install autogluon
+!python -m pip install autogluon[tabarena]
 from autogluon.tabular import TabularDataset, TabularPredictor
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/requirements.txt
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/requirements.txt
@@ -1,3 +1,3 @@
 # TODO: update this to 0806
-autogluon>=1.4.1b20250806
-autogluon.tabular[skex]>=1.4.1b20250806
+autogluon[tabarena]>=1.4.1b20250806
+autogluon.tabular[skex,tabarena]>=1.4.1b20250806

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tool.json
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tool.json
@@ -1,10 +1,13 @@
 {
   "name": "autogluon.tabular",
   "version": "1.4.1.dev",
-  "description": "AutoGluon Tabular automates ML model training for tabular data, excelling at numerical and categorical data processing. It doesn't support NLP or image-based tasks.",
-  "requirements": [],
+  "description": "AutoGluon Tabular automates ML model training for tabular data, excelling at numerical and categorical data processing. It doesn't support NLP or image-based tasks. This tool assumes a GPU-enabled environment; install GPU dependencies with `pip install autogluon[tabarena]`.",
+  "requirements": [
+    "autogluon[tabarena]"
+  ],
   "prompt_template": [
     "DO NOT create validation dataset from training data. Validation score is provided during the training process.",
-    "AutoGluon Tabular requires converting multiple label columns into either a single combined label for mutually exclusive cases or training separate predictors for each label in non-exclusive scenarios."
+    "AutoGluon Tabular requires converting multiple label columns into either a single combined label for mutually exclusive cases or training separate predictors for each label in non-exclusive scenarios.",
+    "Assume a GPU is available and ensure GPU dependencies are installed."
   ]
 }

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates how to create and use custom evaluation metrics in AutoGluon, focusing on what makes them better for model optimization. It covers the implementation of custom metrics for classification, regression, and probability-based tasks, with examples of accuracy, ROC AUC, and MSE. The metrics are defined using make_scorer and can be used for model evaluation and comparison.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates how to prevent AutoGluon from dropping specific features during preprocessing. It covers three key techniques: (1) creating custom models with the `drop_unique=False` parameter to preserve single-value features, (2) implementing a `CustomFeatureGeneratorWithUserOverride` that uses `IdentityFeatureGenerator` to bypass preprocessing for tagged features, and (3) tagging features with special types like 'user_override' to control their processing. These methods are valuable for maintaining important features in machine learning pipelines, ensuring model interpretability, and handling domain-specific features that shouldn't undergo standard transformations.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 
@@ -203,4 +205,3 @@ predictor.fit(
     }
 )
 ```
-

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates how to implement custom models in AutoGluon by extending the AbstractModel class, specifically creating a custom RandomForest implementation. It covers preprocessing with label encoding, dynamic model selection based on problem type, and proper integration with AutoGluon's ecosystem. Key functionalities include custom model training, feature preprocessing, model saving/loading, bagged ensembles for improved performance, and hyperparameter tuning using search spaces. The tutorial helps with tasks like implementing custom ML algorithms within AutoGluon, integrating models with TabularPredictor, and optimizing model performance through bagging and hyperparameter optimization.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-deployment.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-deployment.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: AutoGluon Tabular predictor deployment tutorial provides a guide to AutoGluon TabularPredictor deployment
 
 AI: Summary: AutoGluon TabularPredictor deployment guide
@@ -17,7 +19,7 @@ Summary: AutoGluon TabularPredictor deployment guide
 AI: Summary: AutoGluon TabularPredictor deployment guide provides practical techniques for optimizing and deploying tabular machine learning models. It covers: (1) implementation knowledge of model cloning, deployment optimization, and compilation for speed; (2) coding tasks including creating lightweight model versions for production and preserving model state; and (3) key features like `clone_for_deployment()` for size reduction, `persist()` for memory optimization, and `compile()` for performance enhancement. The tutorial demonstrates how to reduce disk usage while maintaining prediction capabilities and includes best practices for production deployment.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 
@@ -216,8 +218,8 @@ In order to further improve inference efficiency, we can call `.compile()` to au
 convert sklearn function calls into their ONNX equivalents.
 Note that this is currently an experimental feature, which only improves RandomForest and TabularNeuralNetwork models.
 The compilation and inference speed acceleration require installation of `skl2onnx` and `onnxruntime` packages.
-To install supported versions of these packages automatically, we can call `pip install autogluon.tabular[skl2onnx]`
-on top of an existing AutoGluon installation, or `pip install autogluon.tabular[all,skl2onnx]` on a new AutoGluon installation.
+To install supported versions of these packages automatically, we can call `pip install autogluon.tabular[skl2onnx,tabarena]`
+on top of an existing AutoGluon installation, or `pip install autogluon.tabular[all,skl2onnx,tabarena]` on a new AutoGluon installation.
 
 It is important to make sure the predictor is cloned, because once the models are compiled, it won't support fitting.
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial explains GPU acceleration in AutoGluon, covering basic GPU allocation with `num_gpus` parameter, model-specific GPU assignment using hyperparameters dictionary, and multi-modal configuration retrieval. It details special installation requirements for GPU-enabled LightGBM and demonstrates advanced resource allocation techniques to control CPU/GPU usage at predictor, ensemble, and individual model levels. The tutorial helps with optimizing machine learning workflows by efficiently distributing computational resources across different models and training processes, particularly useful for implementing parallel hyperparameter optimization with controlled resource allocation for tabular, multimodal, and gradient-boosted models.
 
 ```python
@@ -34,7 +36,7 @@ Regular configuration is retrieved like this:
 
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-kaggle.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-kaggle.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates how to use AutoGluon for fraud detection in the IEEE Fraud detection competition. AutoGluon's TabularPredictor can be used to train a model for binary classification with minimal code. It shows how to use TabularPredictor for binary classification with TabularPredictor for binary classification with TabularPredictor for binary classification.
 
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-multilabel.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-multilabel.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates AutoGluon's MultilabelPredictor implementation for predicting multiple target columns simultaneously. It covers creating a custom class that manages multiple TabularPredictors, with methods for training, prediction, evaluation, and model persistence. Key features include handling different problem types (regression, classification) for each target, optional correlation consideration between labels during prediction, and customizable evaluation metrics. The code helps with multi-target machine learning tasks, offering flexibility in how predictions are generated and evaluated. The implementation provides a clean API for training multiple models with a single interface while maintaining individual model access.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-essentials.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-essentials.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial covers AutoGluon's TabularPredictor for automated machine learning on tabular data. It demonstrates implementation of quick model training with minimal code, automated handling of data preprocessing, and model deployment. Key functionalities include: loading tabular data, training multiple models simultaneously, making predictions, evaluating performance, and saving/loading models. The tutorial explains different performance presets (from "medium" to "extreme"), feature importance analysis, and optimization strategies for classification and regression tasks. AutoGluon automatically handles missing values, feature engineering, and model selection, making it valuable for rapid prototyping and production-quality predictive modeling with just a few lines of code.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial explains AutoGluon's automatic feature engineering capabilities for tabular data. It covers type-specific processing: numerical columns remain unchanged, categorical columns are integer-encoded, datetime columns are converted to numerical values with extracted temporal features (year, month, day, weekday), and text columns use either n-gram encoding or Transformer networks with MultiModal. The tutorial demonstrates how to implement custom feature generation pipelines using PipelineFeatureGenerator, CategoryFeatureGenerator, and IdentityFeatureGenerator classes, with examples of limiting categorical values and handling specific data types. It also addresses missing value handling and provides tips for customizing the feature engineering process.
 
 ```
@@ -45,7 +47,7 @@ By default a feature generator called [AutoMLPipelineFeatureGenerator](../../api
 
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
@@ -1,3 +1,5 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates implementing foundation models for tabular data using AutoGluon. It covers three key models: Mitra (for small datasets with zero-shot and fine-tuning capabilities), TabICL (leveraging in-context learning for limited data), and TabPFNv2 (utilizing prior knowledge for small datasets). The code shows how to prepare data, train individual models for classification and regression tasks, and create ensembles combining multiple foundation models. Developers can learn to implement these specialized tabular models with different configurations, evaluate their performance, and handle both classification and regression problems with small to medium-sized datasets.
 
 ## Installation
@@ -8,9 +10,9 @@ First, let's install AutoGluon with support for foundational models:
 ```python
 # Individual model installations:
 !pip install uv
-!uv pip install autogluon.tabular[mitra]   # For Mitra
-!uv pip install autogluon.tabular[tabicl]   # For TabICL
-!uv pip install autogluon.tabular[tabpfn]   # For TabPFNv2
+!uv pip install autogluon.tabular[mitra,tabarena]   # For Mitra
+!uv pip install autogluon.tabular[tabicl,tabarena]   # For TabICL
+!uv pip install autogluon.tabular[tabpfn,tabarena]   # For TabPFNv2
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates AutoGluon TabularPredictor for machine learning tasks, covering hyperparameter tuning with search spaces for neural networks and gradient boosting models, model ensembling through stacking/bagging, and decision threshold calibration for binary classification. It explains inference optimization techniques including model persistence, inference speed constraints, ensemble reduction, and model distillation. The tutorial provides practical code examples for accelerating predictions (up to 160x speedup), managing memory usage, and evaluating model performance. Key functionalities include feature importance analysis, loading/saving predictors, making batch and single-instance predictions, and optimizing deployment with techniques like refit_full, persist, and infer_limit parameters.
 
 ```python
-!pip install autogluon.tabular[all]
+!pip install autogluon.tabular[all,tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
@@ -1,7 +1,9 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: This tutorial demonstrates using AutoGluon Multimodal for multimodal classification on the PetFinder dataset. It covers: (1) implementing multimodal machine learning with images and tabular data, including proper image path handling and feature metadata configuration; (2) solving pet adoption prediction tasks by integrating different data types; and (3) key functionalities including data preparation for multimodal inputs, configuring feature metadata to identify image columns, creating appropriate hyperparameter configurations, and training a TabularPredictor that automatically handles mixed data types. The tutorial showcases how to process image paths, configure models for multimodal inputs, and evaluate performance on test data.
 
 ```python
-!pip install autogluon
+!pip install autogluon[tabarena]
 
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-quick-start.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-quick-start.md
@@ -1,10 +1,12 @@
+> **Note:** This tutorial assumes a GPU is available. Install GPU dependencies with `pip install autogluon[tabarena]`.
+
 Summary: "Summary: "Tabular: "Tabular: "Tabular Hypersc 'Hypersc 'Hypertuning 1.Hat 'Hypertuning 'Hypertuning 'Hyperturf: "Hypertuning 'Hyperparred 'Hyperparcel: "Hypertuner: "Hyperturf: "Hypertuner: "Hypertuner: "Hyperturf: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hypertuner: "Hyperparameter Tuning"
 
 Summary: This tutorial demonstrates AutoGluon for automated machine learning with tabular data. It covers: (1) implementing quick ML pipelines with TabularPredictor for automatic feature engineering and model selection; (2) solving classification/regression tasks without manual hyperparameter tuning; and (3) key functionalities including data loading, model training with time constraints, prediction, and performance evaluation through leaderboards. AutoGluon automatically handles the entire ML workflow, recognizing task types and selecting appropriate models, making it ideal for rapid prototyping and building high-performance tabular data models with minimal code.
 
 ```python
 !python -m pip install --upgrade pip
-!python -m pip install autogluon
+!python -m pip install autogluon[tabarena]
 ```
 
 


### PR DESCRIPTION
## Summary
- default all autogluon.tabular tutorials to assume GPU availability
- document GPU dependency via `autogluon[tabarena]`

## Testing
- `pytest -q src/autogluon/assistant/tools_registry/autogluon.tabular`

------
https://chatgpt.com/codex/tasks/task_e_68979889e8dc8326a01f51bb27fc315f