### PR TITLE
docs: remove hyperparameter args from TabularPredictor.fit examples

### DIFF
--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
@@ -84,13 +84,13 @@ ag_roc_auc_scorer = make_scorer(
 
 ### With leaderboard
 ```python
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters='toy')
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
 predictor.leaderboard(test_data, extra_metrics=[ag_roc_auc_scorer, ag_accuracy_scorer])
 ```
 
 ### As evaluation metric
 ```python
-predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data, hyperparameters='toy')
+predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)  # Do not specify the hyperparameters argument
 predictor_custom.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
@@ -129,10 +129,6 @@ predictor.fit(
     train_data=train_data,
     feature_metadata=feature_metadata,
     feature_generator=feature_generator,
-    hyperparameters={
-        'GBM': {},
-        DummyModelKeepUnique: {},
-        # Alternative: DummyModel: {'ag_args_fit': {'drop_unique': False}}
-    }
+    # Do not specify the hyperparameters argument
 )
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
@@ -188,7 +188,7 @@ custom_hyperparameters = {
         {'max_features': 0.9, 'max_depth': 20}
     ]
 }
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters=custom_hyperparameters)
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
 
 # View model performance
 predictor.leaderboard(test_data)
@@ -212,8 +212,8 @@ custom_hyperparameters_hpo = {
 
 predictor = TabularPredictor(label=label).fit(
     train_data,
-    hyperparameters=custom_hyperparameters_hpo,
-    hyperparameter_tune_kwargs='auto',  # enables HPO
+    # Do not specify the hyperparameters argument
+    # Do not specify the hyperparameter_tune_kwargs argument
     time_limit=20
 )
 
@@ -237,7 +237,7 @@ custom_hyperparameters = get_hyperparameter_config('default')
 custom_hyperparameters[CustomRandomForestModel] = best_model_info['hyperparameters']
 
 # Train with custom model alongside default models
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters=custom_hyperparameters)
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
 predictor.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
@@ -29,7 +29,7 @@ hyperparameters = {
 predictor = TabularPredictor(label=label).fit(
     train_data, 
     num_gpus=1,
-    hyperparameters=hyperparameters, 
+    # Do not specify the hyperparameters argument 
 )
 ```
 
@@ -63,7 +63,7 @@ Example with detailed resource allocation:
 predictor.fit(
     num_cpus=32,
     num_gpus=4,
-    hyperparameters={'NN_TORCH': {}},
+    # Do not specify the hyperparameters argument
     num_bag_folds=2,
     ag_args_ensemble={
         'ag_args_fit': {
@@ -75,11 +75,7 @@ predictor.fit(
         'num_cpus': 4,
         'num_gpus': 0.5,
     },
-    hyperparameter_tune_kwargs={
-        'searcher': 'random',
-        'scheduler': 'local',
-        'num_trials': 2
-    }
+    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
@@ -51,7 +51,7 @@ mypipeline = PipelineFeatureGenerator(
 
 # Use custom feature generator with predictor
 predictor = TabularPredictor(label='label')
-predictor.fit(df, hyperparameters={'GBM': {}}, feature_generator=mypipeline)
+predictor.fit(df, feature_generator=mypipeline)  # Do not specify the hyperparameters argument
 ```
 
 ## Missing Value Handling

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
@@ -56,9 +56,7 @@ Mitra is a state-of-the-art tabular foundation model that excels on small datase
 mitra_predictor = TabularPredictor(label='target')
 mitra_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'MITRA': {'fine_tune': False}
-    }
+    # Do not specify the hyperparameters argument
 )
 
 # Evaluate
@@ -71,9 +69,7 @@ mitra_predictor.leaderboard(wine_test_data)
 mitra_predictor_ft = TabularPredictor(label='target')
 mitra_predictor_ft.fit(
     wine_train_data,
-    hyperparameters={
-        'MITRA': {'fine_tune': True, 'fine_tune_steps': 10}
-    },
+    # Do not specify the hyperparameters argument
     time_limit=120  # 2 minutes
 )
 ```
@@ -88,9 +84,7 @@ mitra_reg_predictor = TabularPredictor(
 )
 mitra_reg_predictor.fit(
     housing_train_data.sample(1000),  # sample 1000 rows
-    hyperparameters={
-        'MITRA': {'fine_tune': False}
-    }
+    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -105,9 +99,7 @@ tabicl_predictor = TabularPredictor(
 )
 tabicl_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'TABICL': {},
-    }
+    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -122,9 +114,7 @@ tabpfnv2_predictor = TabularPredictor(
 )
 tabpfnv2_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'TABPFNV2': {}
-    }
+    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -145,7 +135,7 @@ ensemble_predictor = TabularPredictor(
     path='./ensemble_foundation_model'
 ).fit(
     wine_train_data,
-    hyperparameters=multi_foundation_config,
+    # Do not specify the hyperparameters argument
     time_limit=300  # More time for multiple models
 )
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
@@ -63,8 +63,8 @@ hyperparameter_tune_kwargs = {
 predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     train_data,
     time_limit=2*60,  # 2 minutes
-    hyperparameters=hyperparameters,
-    hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    # Do not specify the hyperparameters argument
+    # Do not specify the hyperparameter_tune_kwargs argument
 )
 
 # Predict and evaluate
@@ -91,7 +91,7 @@ predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     num_bag_sets=1,      # number of bagging iterations
     num_stack_levels=1,  # number of stacking levels
     # Reduced hyperparameters for quick demo only
-    hyperparameters={'NN_TORCH': {'num_epochs': 2}, 'GBM': {'num_boost_round': 20}},
+    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -108,7 +108,7 @@ predictor = TabularPredictor(label=label, eval_metric=metric).fit(
 predictor = TabularPredictor(label=label, eval_metric='balanced_accuracy', path=save_path).fit(
     train_data, auto_stack=True,
     calibrate_decision_threshold=False,  # Disabled for demonstration
-    hyperparameters={'FASTAI': {'num_epochs': 10}, 'GBM': {'num_boost_round': 200}}  # For quick demo only
+    # Do not specify the hyperparameters argument
 )
 predictor.leaderboard(test_data)
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
@@ -75,7 +75,7 @@ hyperparameters = get_hyperparameter_config('multimodal')
 from autogluon.tabular import TabularPredictor
 predictor = TabularPredictor(label=label).fit(
     train_data=train_data,
-    hyperparameters=hyperparameters,
+    # Do not specify the hyperparameters argument
     feature_metadata=feature_metadata,
     time_limit=900,  # 15 minutes time limit
 )

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
@@ -284,7 +284,7 @@ train_data.head(5)
 ```python
 from autogluon.tabular import TabularPredictor
 
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters='toy')
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
 
 predictor.leaderboard(test_data)
 ```
@@ -300,7 +300,7 @@ We can also pass our custom metric into the Predictor itself by specifying it du
 
 
 ```python
-predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data, hyperparameters='toy')
+predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)  # Do not specify the hyperparameters argument
 
 predictor_custom.leaderboard(test_data)
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
@@ -197,11 +197,6 @@ predictor.fit(
     train_data=train_data,
     feature_metadata=feature_metadata,  # feature metadata with your overrides
     feature_generator=feature_generator,  # your custom feature generator that handles the overrides
-    hyperparameters={
-        'GBM': {},  # Can fit your custom model alongside default models
-        DummyModel: {},  # Will drop dummy_feature
-        DummyModelKeepUnique: {},  # Will not drop dummy_feature
-        # DummyModel: {'ag_args_fit': {'drop_unique': False}},  # This is another way to get same result as using DummyModelKeepUnique
-    }
+    # Do not specify the hyperparameters argument
 )
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
@@ -269,7 +269,7 @@ from autogluon.tabular import TabularPredictor
 
 # custom_hyperparameters = {CustomRandomForestModel: {}}  # train 1 CustomRandomForestModel Model with default hyperparameters
 custom_hyperparameters = {CustomRandomForestModel: [{}, {'max_depth': 10}, {'max_features': 0.9, 'max_depth': 20}]}  # Train 3 CustomRandomForestModel with different hyperparameters
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters=custom_hyperparameters)
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
 ```
 
 ### Predictor leaderboard
@@ -308,8 +308,8 @@ custom_hyperparameters_hpo = {CustomRandomForestModel: {
 }}
 # Hyperparameter tune CustomRandomForestModel for 20 seconds
 predictor = TabularPredictor(label=label).fit(train_data,
-                                              hyperparameters=custom_hyperparameters_hpo,
-                                              hyperparameter_tune_kwargs='auto',  # enables HPO
+    # Do not specify the hyperparameters argument
+    # Do not specify the hyperparameter_tune_kwargs argument
                                               time_limit=20)
 ```
 
@@ -360,8 +360,8 @@ print(custom_hyperparameters)
 
 
 ```python
-predictor = TabularPredictor(label=label).fit(train_data, hyperparameters=custom_hyperparameters)  # Train the default models plus a single tuned CustomRandomForestModel
-# predictor = TabularPredictor(label=label).fit(train_data, hyperparameters=custom_hyperparameters, presets='best_quality')  # We can even use the custom model in a multi-layer stack ensemble
+predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument  # Train the default models plus a single tuned CustomRandomForestModel
+# predictor = TabularPredictor(label=label).fit(train_data, presets='best_quality')  # Do not specify the hyperparameters argument  # We can even use the custom model in a multi-layer stack ensemble
 predictor.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
@@ -22,7 +22,7 @@ hyperparameters = {
 predictor = TabularPredictor(label=label).fit(
     train_data, 
     num_gpus=1,
-    hyperparameters=hyperparameters, 
+    # Do not specify the hyperparameters argument 
 )
 ```
 
@@ -78,9 +78,7 @@ As an example, consider the following scenario
 predictor.fit(
     num_cpus=32,
     num_gpus=4,
-    hyperparameters={
-        'NN_TORCH': {},
-    },
+    # Do not specify the hyperparameters argument
     num_bag_folds=2,
     ag_args_ensemble={
         'ag_args_fit': {
@@ -91,12 +89,8 @@ predictor.fit(
     ag_args_fit={
         'num_cpus': 4,
         'num_gpus': 0.5,
-    }
-    hyperparameter_tune_kwargs={
-        'searcher': 'random',
-        'scheduler': 'local',
-        'num_trials': 2
-    }
+    },
+    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
@@ -95,7 +95,7 @@ To get more details, we should call the pipeline as part of `TabularPredictor.fi
 ```python
 df = pd.concat([dfx, dfy], axis=1)
 predictor = TabularPredictor(label='label')
-predictor.fit(df, hyperparameters={'GBM' : {}}, feature_generator=auto_ml_pipeline_feature_generator)
+predictor.fit(df, feature_generator=auto_ml_pipeline_feature_generator)  # Do not specify the hyperparameters argument
 ```
 
 Reading the output, note that:

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
@@ -94,9 +94,7 @@ print("Training Mitra classifier on classification dataset...")
 mitra_predictor = TabularPredictor(label='target')
 mitra_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'MITRA': {'fine_tune': False}
-    },
+    # Do not specify the hyperparameters argument
    )
 
 print("\nMitra training completed!")
@@ -128,9 +126,7 @@ mitra_predictor.leaderboard(wine_test_data)
 mitra_predictor_ft = TabularPredictor(label='target')
 mitra_predictor_ft.fit(
     wine_train_data,
-    hyperparameters={
-        'MITRA': {'fine_tune': True, 'fine_tune_steps': 10}
-    },
+    # Do not specify the hyperparameters argument
     time_limit=120,  # 2 minutes
    )
 
@@ -162,9 +158,7 @@ mitra_reg_predictor = TabularPredictor(
 )
 mitra_reg_predictor.fit(
     housing_train_data.sample(1000), # sample 1000 rows
-    hyperparameters={
-        'MITRA': {'fine_tune': False}
-    },
+    # Do not specify the hyperparameters argument
 )
 
 # Evaluate regression performance
@@ -192,9 +186,7 @@ tabicl_predictor = TabularPredictor(
 )
 tabicl_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'TABICL': {},
-    },
+    # Do not specify the hyperparameters argument
 )
 
 # Show prediction probabilities for first few samples
@@ -226,11 +218,7 @@ tabpfnv2_predictor = TabularPredictor(
 )
 tabpfnv2_predictor.fit(
     wine_train_data,
-    hyperparameters={
-        'TABPFNV2': {
-            # TabPFNv2 works best with default parameters on small datasets
-        },
-    },
+    # Do not specify the hyperparameters argument
 )
 
 # Show prediction probabilities for first few samples
@@ -262,10 +250,9 @@ ensemble_predictor = TabularPredictor(
     label='target',
     path='./ensemble_foundation_model'
 ).fit(
-    wine_train_data,
-    hyperparameters=multi_foundation_config,
-    time_limit=300,  # More time for multiple models
-)
+        wine_train_data,
+        time_limit=300,  # More time for multiple models
+    )  # Do not specify the hyperparameters argument
 
 # Evaluate ensemble performance
 ensemble_predictor.leaderboard(wine_test_data)

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
@@ -76,8 +76,8 @@ hyperparameter_tune_kwargs = {  # HPO is not performed unless hyperparameter_tun
 predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     train_data,
     time_limit=time_limit,
-    hyperparameters=hyperparameters,
-    hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    # Do not specify the hyperparameters argument
+    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 
@@ -124,7 +124,7 @@ You should not provide `tuning_data` when stacking/bagging, and instead provide 
 predictor = TabularPredictor(label=label, eval_metric='balanced_accuracy', path=save_path).fit(
     train_data, auto_stack=True,
     calibrate_decision_threshold=False,  # Disabling for demonstration in next section
-    hyperparameters={'FASTAI': {'num_epochs': 10}, 'GBM': {'num_boost_round': 200}}  # last 2 arguments are for quick demo, omit them in real applications
+    # Do not specify the hyperparameters argument
 )
 predictor.leaderboard(test_data)
 ```
@@ -506,7 +506,7 @@ Another option is to specify more lightweight hyperparameters:
 
 
 ```python
-predictor_light = TabularPredictor(label=label, eval_metric=metric).fit(train_data, hyperparameters='very_light', time_limit=30)
+predictor_light = TabularPredictor(label=label, eval_metric=metric).fit(train_data, time_limit=30)  # Do not specify the hyperparameters argument
 ```
 
 Here you can set `hyperparameters` to either 'light', 'very_light', or 'toy' to obtain progressively smaller (but less accurate) models and predictors. Advanced users may instead try manually specifying particular models' hyperparameters in order to make them faster/smaller.

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
@@ -195,7 +195,7 @@ Now we will train a TabularPredictor on the dataset, using the feature metadata 
 from autogluon.tabular import TabularPredictor
 predictor = TabularPredictor(label=label).fit(
     train_data=train_data,
-    hyperparameters=hyperparameters,
+    # Do not specify the hyperparameters argument
     feature_metadata=feature_metadata,
     time_limit=900,
 )


### PR DESCRIPTION
## Summary
- remove explicit `hyperparameters` and `hyperparameter_tune_kwargs` arguments from TabularPredictor.fit examples
- add comments reminding users not to specify these arguments

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant')*

------
https://chatgpt.com/codex/tasks/task_e_6899271b62948326bbbdf90efad8e21d