### PR TITLE
Clarify training instructions in Python coder prompt

### DIFF
--- a/src/autogluon/assistant/prompts/python_coder_prompt.py
+++ b/src/autogluon/assistant/prompts/python_coder_prompt.py
@@ -22,7 +22,9 @@ ONLY save files to the working directory: {output_folder}.
    - Remove the unneccesary index column (if applicable)
 
 2. Model training:
-   - Use {selected_tool} with appropriate parameters for the task
+   - Use {selected_tool} with appropriate parameters for the task.
+   - **Important:** DO NOT specify the `hyperparameters` argument in the `fit()` call.
+   - **Important:** DO NOT specify the `hyperparameter_tune_kwargs` argument in the `fit()` call.
    - If a model is trained, save it in a folder with random timestamp within {output_folder}
 
 3. Prediction:


### PR DESCRIPTION
## Summary
- Warn users not to set `hyperparameters` or `hyperparameter_tune_kwargs` in `fit()` when training
- Retain guidance to save trained models in a timestamped folder

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_anthropic'; FileNotFoundError: mlzero-mcp-client; AssertionError: Welcome message not found)*

------
https://chatgpt.com/codex/tasks/task_e_68992daf6a988326b1151614fa372363