### PR TITLE
Add prerelease flag to uv pip install instructions

### DIFF
--- a/src/autogluon/assistant/prompts/bash_coder_prompt.py
+++ b/src/autogluon/assistant/prompts/bash_coder_prompt.py
@@ -86,7 +86,7 @@ Create and configure a conda environment in "{ENV_FOLDER_NAME}" folder under {it
  - Python version: 3.11
  - Activate the environment
  - pip install uv
- - Install required packages from {common_env_file} and {selected_tool_env_file} using uv pip install -r {selected_tool_env_file} -r {common_env_file}"""
+ - Install required packages from {common_env_file} and {selected_tool_env_file} using uv pip install --prerelease=allow -r {selected_tool_env_file} -r {common_env_file}"""
 
         if not create_venv:
             env_prompt += f"\n - Do not install or update any package unless there is an error due to the missing package.\n - Do NOT upgrade {selected_tool} which is already installed."


### PR DESCRIPTION
## Summary
- allow prerelease packages when installing dependencies via uv pip

## Testing
- `python -m isort src/autogluon/assistant/prompts/bash_coder_prompt.py`
- `python -m black src/autogluon/assistant/prompts/bash_coder_prompt.py`
- `ruff check src/autogluon/assistant/prompts/bash_coder_prompt.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant', ModuleNotFoundError: No module named 'pytest_asyncio', ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_689ab14f01808326985db160c1672da8