### PR TITLE
Handle missing description files gracefully

### DIFF
--- a/src/autogluon/assistant/agents/description_file_retriever_agent.py
+++ b/src/autogluon/assistant/agents/description_file_retriever_agent.py
@@ -56,6 +56,10 @@ class DescriptionFileRetrieverAgent(BaseAgent):
 
         description_files = self.description_file_retriever_prompt.parse(response)
 
+        if description_files and "No project description" in description_files[0]:
+            logger.warning("No description files found by DescriptionFileRetrieverAgent.")
+            return []
+
         self.manager.log_agent_end("DescriptionFileRetrieverAgent: description file list extracted.")
 
         return description_files


### PR DESCRIPTION
## Summary
- avoid raising error when DescriptionFileRetrieverAgent finds no description files

## Testing
- `pytest tests/unittests -q` *(fails: No module named 'pandas', 'aiohttp', 'autogluon', 'streamlit')*
- `pip install -e .` *(fails: Package 'autogluon-assistant' requires a different Python: 3.12.10 not in '<3.12,>=3.8')*

------
https://chatgpt.com/codex/tasks/task_e_689abc4b82588326bef5e35e08b19026