### PR TITLE
Validate description file paths before reading

### DIFF
--- a/src/autogluon/assistant/prompts/task_descriptor_prompt.py
+++ b/src/autogluon/assistant/prompts/task_descriptor_prompt.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Optional
 
 from .base_prompt import BasePrompt
@@ -30,6 +31,11 @@ Be very clear about the problem type (e.g. audio classification/image regression
 
         file_contents = []
         for filename in self.manager.description_files:
+            # Validate filename before attempting to read
+            if not isinstance(filename, str) or not os.path.isfile(filename):
+                logger.warning(f"Description file not found or invalid path, skipping: {filename}")
+                continue
+
             try:
                 with open(filename, "r") as f:
                     content = f.read()


### PR DESCRIPTION
## Summary
- Verify that each provided description file path exists before reading
- Log a warning and skip invalid paths to avoid runtime errors

## Testing
- `ruff check src/autogluon/assistant/prompts/task_descriptor_prompt.py`
- `pytest tests/unittests -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant', ModuleNotFoundError: No module named 'pytest_asyncio', ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_689ac3d7967c8326aa6f68c887832919