### PR TITLE
feat: clarify python code format

### DIFF
--- a/src/autogluon/assistant/prompts/python_coder_prompt.py
+++ b/src/autogluon/assistant/prompts/python_coder_prompt.py
@@ -96,7 +96,7 @@ Please provide the complete Python script that accomplishes these tasks, ensurin
         # Add format instruction if configured
         if self.llm_config.add_coding_format_instruction:
             format_instruction = (
-                "Please format your response with the code in a ```python``` code block to make it easily extractable."
+                "IMPORTANT: You MUST wrap the Python code in a single fenced code block starting with ```python and ending with ```. Do not include any text, explanation or note outside of this code block."
             )
             prompt = f"{prompt}\n\n{format_instruction}"
 


### PR DESCRIPTION
## Summary
- clarify Python code formatting requirement to ensure single fenced code block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant', ModuleNotFoundError: No module named 'pytest_asyncio', ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_689aca7247f48326923a8e159dcd2f9c