### PR TITLE
feat: enforce python fenced code block in reader prompt

### DIFF
--- a/src/autogluon/assistant/prompts/python_reader_prompt.py
+++ b/src/autogluon/assistant/prompts/python_reader_prompt.py
@@ -50,7 +50,7 @@ Return ONLY the Python code, no explanations. The code should be self-contained 
         # Add format instruction if configured
         if self.llm_config.add_coding_format_instruction:
             format_instruction = (
-                "Please format your response with the code in a ```python``` code block to make it easily extractable."
+                "IMPORTANT: You MUST wrap the Python code in a single fenced code block starting with ```python and ending with ```. Return ONLY the Python code, no explanations."
             )
             prompt = f"{prompt}\n\n{format_instruction}"
 


### PR DESCRIPTION
## Summary
- require Python reader prompt responses to be returned in a single ```python``` fenced code block when formatting instruction is enabled

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic'; FileNotFoundError: mlzero-mcp-client; AssertionError: Welcome message not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aca96ce288326b1bdaf230e7eda79