### PR TITLE
chore: add einops dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "requests>=2.28.0",
   "boto3>=1.28.0",
   "mcp>=0.1.0",
+  "einops>=0.7,<0.9",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add einops>=0.7,<0.9 to project dependencies

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'autogluon.assistant')

------
https://chatgpt.com/codex/tasks/task_e_689ad42ff5288326b2eb18841ffddb43