### PR TITLE
Switch to faiss-gpu in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "langgraph",
   "chardet>=5.2.0",
   "FlagEmbedding>=1.3.5",
-  "faiss-cpu",
+  "faiss-gpu",
   "importlib-resources>=6.4.5",
   "langchain>=0.3.3",
   "langchain_openai>=0.2.2",


### PR DESCRIPTION
## Summary
- replace `faiss-cpu` with `faiss-gpu` in `pyproject.toml`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'autogluon', 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_689db118c70883269c93800dd16ed6ef