### PR TITLE
Remove coder model override in default config

### DIFF
--- a/src/autogluon/assistant/configs/default.yaml
+++ b/src/autogluon/assistant/configs/default.yaml
@@ -36,8 +36,7 @@ llm: &default_llm
 
 coder:
   <<: *default_llm
-  model: us.anthropic.claude-opus-4-1-20250805-v1:0
-  multi_turn: True 
+  multi_turn: True
 
 executer:
   <<: *default_llm


### PR DESCRIPTION
## Summary
- remove hardcoded coder model so it inherits default LLM settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant')*
- `pip install -e .[dev]` *(fails: Package 'autogluon-assistant' requires a different Python: 3.12.10 not in '<3.12,>=3.8')*


------
https://chatgpt.com/codex/tasks/task_e_689e939e16b88326aff65539abef2677