### PR TITLE
chore: use faiss-cpu dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "langgraph",
   "chardet>=5.2.0",
   "FlagEmbedding>=1.3.5",
-  "faiss-gpu",
+  "faiss-cpu",
   "importlib-resources>=6.4.5",
   "langchain>=0.3.3",
   "langchain_openai>=0.2.2",


### PR DESCRIPTION
## Summary
- replace faiss-gpu with faiss-cpu in project dependencies

## Testing
- `pytest tests/unittests -q` *(fails: No module named 'autogluon.assistant', 'pytest_asyncio', 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_689eb4090e308326ba7968af3c798fb6