### PR TITLE
Remove hyperparameter constraints from coder prompt

### DIFF
--- a/src/autogluon/assistant/prompts/python_coder_prompt.py
+++ b/src/autogluon/assistant/prompts/python_coder_prompt.py
@@ -23,8 +23,6 @@ ONLY save files to the working directory: {output_folder}.
 
 2. Model training:
    - Use {selected_tool} with appropriate parameters for the task.
-   - **Important:** DO NOT specify the `hyperparameters` argument in the `fit()` call.
-   - **Important:** DO NOT specify the `hyperparameter_tune_kwargs` argument in the `fit()` call.
    - If a model is trained, save it in a folder with random timestamp within {output_folder}
 
 3. Prediction:


### PR DESCRIPTION
## Summary
- delete hyperparameter and hyperparameter_tune_kwargs restrictions from python_coder_prompt template

## Testing
- `pytest tests/unittests -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant'; No module named 'pytest_asyncio'; No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_68a024a8403c8326a161ecd6a392f311