### PR TITLE
docs: remove hyperparameter argument comments

### DIFF
--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-metric.md
@@ -84,13 +84,13 @@ ag_roc_auc_scorer = make_scorer(
 
 ### With leaderboard
 ```python
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
+predictor = TabularPredictor(label=label).fit(train_data)
 predictor.leaderboard(test_data, extra_metrics=[ag_roc_auc_scorer, ag_accuracy_scorer])
 ```
 
 ### As evaluation metric
 ```python
-predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)  # Do not specify the hyperparameters argument
+predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)
 predictor_custom.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model-advanced.md
@@ -129,6 +129,5 @@ predictor.fit(
     train_data=train_data,
     feature_metadata=feature_metadata,
     feature_generator=feature_generator,
-    # Do not specify the hyperparameters argument
 )
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-custom-model.md
@@ -188,7 +188,7 @@ custom_hyperparameters = {
         {'max_features': 0.9, 'max_depth': 20}
     ]
 }
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
+predictor = TabularPredictor(label=label).fit(train_data)
 
 # View model performance
 predictor.leaderboard(test_data)
@@ -212,8 +212,6 @@ custom_hyperparameters_hpo = {
 
 predictor = TabularPredictor(label=label).fit(
     train_data,
-    # Do not specify the hyperparameters argument
-    # Do not specify the hyperparameter_tune_kwargs argument
     time_limit=20
 )
 
@@ -237,7 +235,7 @@ custom_hyperparameters = get_hyperparameter_config('default')
 custom_hyperparameters[CustomRandomForestModel] = best_model_info['hyperparameters']
 
 # Train with custom model alongside default models
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
+predictor = TabularPredictor(label=label).fit(train_data)
 predictor.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/advanced/tabular-gpu.md
@@ -29,7 +29,6 @@ hyperparameters = {
 predictor = TabularPredictor(label=label).fit(
     train_data, 
     num_gpus=1,
-    # Do not specify the hyperparameters argument 
 )
 ```
 
@@ -63,7 +62,6 @@ Example with detailed resource allocation:
 predictor.fit(
     num_cpus=32,
     num_gpus=4,
-    # Do not specify the hyperparameters argument
     num_bag_folds=2,
     ag_args_ensemble={
         'ag_args_fit': {
@@ -75,7 +73,6 @@ predictor.fit(
         'num_cpus': 4,
         'num_gpus': 0.5,
     },
-    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-feature-engineering.md
@@ -51,7 +51,7 @@ mypipeline = PipelineFeatureGenerator(
 
 # Use custom feature generator with predictor
 predictor = TabularPredictor(label='label')
-predictor.fit(df, feature_generator=mypipeline)  # Do not specify the hyperparameters argument
+predictor.fit(df, feature_generator=mypipeline)
 ```
 
 ## Missing Value Handling

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-foundational-models.md
@@ -56,7 +56,6 @@ Mitra is a state-of-the-art tabular foundation model that excels on small datase
 mitra_predictor = TabularPredictor(label='target')
 mitra_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
 )
 
 # Evaluate
@@ -69,7 +68,6 @@ mitra_predictor.leaderboard(wine_test_data)
 mitra_predictor_ft = TabularPredictor(label='target')
 mitra_predictor_ft.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
     time_limit=120  # 2 minutes
 )
 ```
@@ -84,7 +82,6 @@ mitra_reg_predictor = TabularPredictor(
 )
 mitra_reg_predictor.fit(
     housing_train_data.sample(1000),  # sample 1000 rows
-    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -99,7 +96,6 @@ tabicl_predictor = TabularPredictor(
 )
 tabicl_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -114,7 +110,6 @@ tabpfnv2_predictor = TabularPredictor(
 )
 tabpfnv2_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -135,7 +130,6 @@ ensemble_predictor = TabularPredictor(
     path='./ensemble_foundation_model'
 ).fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
     time_limit=300  # More time for multiple models
 )
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-indepth.md
@@ -63,8 +63,6 @@ hyperparameter_tune_kwargs = {
 predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     train_data,
     time_limit=2*60,  # 2 minutes
-    # Do not specify the hyperparameters argument
-    # Do not specify the hyperparameter_tune_kwargs argument
 )
 
 # Predict and evaluate
@@ -91,7 +89,6 @@ predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     num_bag_sets=1,      # number of bagging iterations
     num_stack_levels=1,  # number of stacking levels
     # Reduced hyperparameters for quick demo only
-    # Do not specify the hyperparameters argument
 )
 ```
 
@@ -108,7 +105,6 @@ predictor = TabularPredictor(label=label, eval_metric=metric).fit(
 predictor = TabularPredictor(label=label, eval_metric='balanced_accuracy', path=save_path).fit(
     train_data, auto_stack=True,
     calibrate_decision_threshold=False,  # Disabled for demonstration
-    # Do not specify the hyperparameters argument
 )
 predictor.leaderboard(test_data)
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/condensed_tutorials/tabular-multimodal.md
@@ -75,7 +75,6 @@ hyperparameters = get_hyperparameter_config('multimodal')
 from autogluon.tabular import TabularPredictor
 predictor = TabularPredictor(label=label).fit(
     train_data=train_data,
-    # Do not specify the hyperparameters argument
     feature_metadata=feature_metadata,
     time_limit=900,  # 15 minutes time limit
 )

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-metric.md
@@ -284,7 +284,7 @@ train_data.head(5)
 ```python
 from autogluon.tabular import TabularPredictor
 
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
+predictor = TabularPredictor(label=label).fit(train_data)
 
 predictor.leaderboard(test_data)
 ```
@@ -300,7 +300,7 @@ We can also pass our custom metric into the Predictor itself by specifying it du
 
 
 ```python
-predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)  # Do not specify the hyperparameters argument
+predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data)
 
 predictor_custom.leaderboard(test_data)
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model-advanced.md
@@ -197,6 +197,5 @@ predictor.fit(
     train_data=train_data,
     feature_metadata=feature_metadata,  # feature metadata with your overrides
     feature_generator=feature_generator,  # your custom feature generator that handles the overrides
-    # Do not specify the hyperparameters argument
 )
 ```

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-custom-model.md
@@ -269,7 +269,7 @@ from autogluon.tabular import TabularPredictor
 
 # custom_hyperparameters = {CustomRandomForestModel: {}}  # train 1 CustomRandomForestModel Model with default hyperparameters
 custom_hyperparameters = {CustomRandomForestModel: [{}, {'max_depth': 10}, {'max_features': 0.9, 'max_depth': 20}]}  # Train 3 CustomRandomForestModel with different hyperparameters
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument
+predictor = TabularPredictor(label=label).fit(train_data)
 ```
 
 ### Predictor leaderboard
@@ -308,8 +308,6 @@ custom_hyperparameters_hpo = {CustomRandomForestModel: {
 }}
 # Hyperparameter tune CustomRandomForestModel for 20 seconds
 predictor = TabularPredictor(label=label).fit(train_data,
-    # Do not specify the hyperparameters argument
-    # Do not specify the hyperparameter_tune_kwargs argument
                                               time_limit=20)
 ```
 
@@ -360,8 +358,8 @@ print(custom_hyperparameters)
 
 
 ```python
-predictor = TabularPredictor(label=label).fit(train_data)  # Do not specify the hyperparameters argument  # Train the default models plus a single tuned CustomRandomForestModel
-# predictor = TabularPredictor(label=label).fit(train_data, presets='best_quality')  # Do not specify the hyperparameters argument  # We can even use the custom model in a multi-layer stack ensemble
+predictor = TabularPredictor(label=label).fit(train_data)  # Train the default models plus a single tuned CustomRandomForestModel
+# predictor = TabularPredictor(label=label).fit(train_data, presets='best_quality')  # We can even use the custom model in a multi-layer stack ensemble
 predictor.leaderboard(test_data)
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/advanced/tabular-gpu.md
@@ -22,7 +22,6 @@ hyperparameters = {
 predictor = TabularPredictor(label=label).fit(
     train_data, 
     num_gpus=1,
-    # Do not specify the hyperparameters argument 
 )
 ```
 
@@ -78,7 +77,6 @@ As an example, consider the following scenario
 predictor.fit(
     num_cpus=32,
     num_gpus=4,
-    # Do not specify the hyperparameters argument
     num_bag_folds=2,
     ag_args_ensemble={
         'ag_args_fit': {
@@ -90,7 +88,6 @@ predictor.fit(
         'num_cpus': 4,
         'num_gpus': 0.5,
     },
-    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-feature-engineering.md
@@ -95,7 +95,7 @@ To get more details, we should call the pipeline as part of `TabularPredictor.fi
 ```python
 df = pd.concat([dfx, dfy], axis=1)
 predictor = TabularPredictor(label='label')
-predictor.fit(df, feature_generator=auto_ml_pipeline_feature_generator)  # Do not specify the hyperparameters argument
+predictor.fit(df, feature_generator=auto_ml_pipeline_feature_generator)
 ```
 
 Reading the output, note that:

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-foundational-models.md
@@ -94,7 +94,6 @@ print("Training Mitra classifier on classification dataset...")
 mitra_predictor = TabularPredictor(label='target')
 mitra_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
    )
 
 print("\nMitra training completed!")
@@ -126,7 +125,6 @@ mitra_predictor.leaderboard(wine_test_data)
 mitra_predictor_ft = TabularPredictor(label='target')
 mitra_predictor_ft.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
     time_limit=120,  # 2 minutes
    )
 
@@ -158,7 +156,6 @@ mitra_reg_predictor = TabularPredictor(
 )
 mitra_reg_predictor.fit(
     housing_train_data.sample(1000), # sample 1000 rows
-    # Do not specify the hyperparameters argument
 )
 
 # Evaluate regression performance
@@ -186,7 +183,6 @@ tabicl_predictor = TabularPredictor(
 )
 tabicl_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
 )
 
 # Show prediction probabilities for first few samples
@@ -218,7 +214,6 @@ tabpfnv2_predictor = TabularPredictor(
 )
 tabpfnv2_predictor.fit(
     wine_train_data,
-    # Do not specify the hyperparameters argument
 )
 
 # Show prediction probabilities for first few samples
@@ -252,7 +247,7 @@ ensemble_predictor = TabularPredictor(
 ).fit(
         wine_train_data,
         time_limit=300,  # More time for multiple models
-    )  # Do not specify the hyperparameters argument
+    )
 
 # Evaluate ensemble performance
 ensemble_predictor.leaderboard(wine_test_data)

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-indepth.md
@@ -76,8 +76,6 @@ hyperparameter_tune_kwargs = {  # HPO is not performed unless hyperparameter_tun
 predictor = TabularPredictor(label=label, eval_metric=metric).fit(
     train_data,
     time_limit=time_limit,
-    # Do not specify the hyperparameters argument
-    # Do not specify the hyperparameter_tune_kwargs argument
 )
 ```
 
@@ -124,7 +122,6 @@ You should not provide `tuning_data` when stacking/bagging, and instead provide 
 predictor = TabularPredictor(label=label, eval_metric='balanced_accuracy', path=save_path).fit(
     train_data, auto_stack=True,
     calibrate_decision_threshold=False,  # Disabling for demonstration in next section
-    # Do not specify the hyperparameters argument
 )
 predictor.leaderboard(test_data)
 ```
@@ -506,7 +503,7 @@ Another option is to specify more lightweight hyperparameters:
 
 
 ```python
-predictor_light = TabularPredictor(label=label, eval_metric=metric).fit(train_data, time_limit=30)  # Do not specify the hyperparameters argument
+predictor_light = TabularPredictor(label=label, eval_metric=metric).fit(train_data, time_limit=30)
 ```
 
 Here you can set `hyperparameters` to either 'light', 'very_light', or 'toy' to obtain progressively smaller (but less accurate) models and predictors. Advanced users may instead try manually specifying particular models' hyperparameters in order to make them faster/smaller.

--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/tutorials/tabular-multimodal.md
@@ -195,7 +195,6 @@ Now we will train a TabularPredictor on the dataset, using the feature metadata 
 from autogluon.tabular import TabularPredictor
 predictor = TabularPredictor(label=label).fit(
     train_data=train_data,
-    # Do not specify the hyperparameters argument
     feature_metadata=feature_metadata,
     time_limit=900,
 )


### PR DESCRIPTION
## Summary
- remove "Do not specify the hyperparameters argument" notes across tabular tutorials
- remove "Do not specify the hyperparameter_tune_kwargs argument" notes in affected markdown files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant'; ModuleNotFoundError: No module named 'pytest_asyncio'; ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68a02ffaa81483268dd463778ae3a7f9