### PR TITLE
chore: update autogluon.tabular requirements

### DIFF
--- a/src/autogluon/assistant/tools_registry/autogluon.tabular/requirements.txt
+++ b/src/autogluon/assistant/tools_registry/autogluon.tabular/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: update this to 0806
-autogluon[tabarena]>=1.4.1b20250806
-autogluon.tabular[skex,tabarena]>=1.4.1b20250806
+autogluon>=1.4.1b20250806
+autogluon.tabular[skex]>=1.4.1b20250806


### PR DESCRIPTION
## Summary
- update autogluon.tabular tool requirements

## Testing
- `pytest tests/unittests/webui/test_backend/test_queue_manager.py` *(fails: No module named 'autogluon.assistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a49ae51dcc8326a736ee6f1b8ac43a