### PR TITLE
Add PyPDF2 dependency for PDF processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "boto3>=1.28.0",
   "mcp>=0.1.0",
   "einops>=0.7,<0.9",
+  "PyPDF2>=3.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add PyPDF2 to project dependencies for PDF handling

## Testing
- `python - <<'PY'
import PyPDF2
with open('sample.pdf', 'rb') as f:
    reader = PyPDF2.PdfReader(f)
    text = ''.join(page.extract_text() for page in reader.pages)
print('PDF text snippet:', text[:50])
print('Number of pages:', len(reader.pages))
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: ModuleNotFoundError: No module named 'autogluon.assistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a5f54337d883268d981b58722c9eca